### PR TITLE
fix: tmuxエラーハンドリングの改善と説明追加

### DIFF
--- a/articles/90f5fc48a6dea7.md
+++ b/articles/90f5fc48a6dea7.md
@@ -53,7 +53,13 @@ publication_name: "studio_prairie"
 
 ## セキュリティ対策
 
-本システムでは`--dangerously-skip-permissions`オプションを使用していますが、Anthropic公式のdevcontainerをベースに、以下の多層防御を実装しています。結果として
+本システムでは`--dangerously-skip-permissions`オプションを使用していますが、Anthropic公式のdevcontainerをベースに、以下の多層防御を実装しています。
+
+:::message
+Claude Codeの`--dangerously-skip-permissions`オプションは、通常のインタラクティブモードでClaude Codeが実行前に求める確認をスキップし、自動化を可能にするオプションです。このオプションを使用することで、tmuxを介した自動化が可能になりますが、セキュリティリスクも伴うため、本記事で紹介するような多層防御が必要です。
+:::
+
+結果として
 
 - 意図しないサーバーにデータを送信することはできません
 - ホストマシンの重要ファイルにアクセスすることはできません
@@ -187,7 +193,7 @@ while true; do
   echo "$(date): Boss agent restart"
   git -C /workspace/repo pull # マージを反映して最新の状態にする
   # 既存のbossセッションを終了
-  tmux kill-session -t boss 2>/dev/null || true
+  tmux kill-session -t boss || true
   # 新しいbossセッションを開始
   tmux new -d -s boss 'claude ".devcontainer/boss.md の指示に従って作業してください" --dangerously-skip-permissions'
   tmux send-keys -t boss Enter


### PR DESCRIPTION
## Summary
- boss.shのtmux kill-sessionコマンドから不要な`2>/dev/null`を削除
- `--dangerously-skip-permissions`オプションについての説明を追加

## Test plan
- [ ] 記事の内容が正確に反映されていることを確認
- [ ] 技術的な説明が正しいことを確認

## 参考
参照先のPRの内容を抽象化して記事側に反映しました。

🤖 Generated with [Claude Code](https://claude.ai/code)